### PR TITLE
Fix formatting in circular_domain description

### DIFF
--- a/docs/src/linters_config.md
+++ b/docs/src/linters_config.md
@@ -45,7 +45,7 @@ Full example configs are in the [config](https://github.com/zgornel/DataLinter/t
 |`empty_example`|Detects completely empty rows|Any dataset|-|
 |`uncommon_signs`|Flags numerical columns with very few opposite signs|Signed numeric data|-|
 |`long_tailed_distrib`|Detects long-tailed distributions|Numerical features|`drop_proportion`, `zscore_multiplier`|
-|`circular_domain`|Identifies circular data (hours| degrees| etc.)|Angular / periodic data|-|
+|`circular_domain`|Identifies circular data (hours, degrees, etc.)|Angular / periodic data|-|
 |`many_missing_values`|Warns about columns with high missingness|Any dataset|`threshold`|
 |`negative_values`|Checks for negative values in a column|Count / amount columns|-|
 |`imbalanced_target_variable`|Detects imbalanced target classes|Classification targets|`threshold`|


### PR DESCRIPTION
Fix formatting, so the content stays in its column.

Before:

<img width="856" height="77" alt="billede" src="https://github.com/user-attachments/assets/28896d88-1f7a-47ac-a681-1b2187a2fba6" />

After:

<img width="984" height="69" alt="billede" src="https://github.com/user-attachments/assets/64b9fadd-6aa7-4c8a-a53b-5c5f9b217884" />


